### PR TITLE
Fix for the rotating card oddly moving views above its hierarchy

### DIFF
--- a/Sources/FabulaItemsProvider/Items/P278_RotatingPlayingCard.swift
+++ b/Sources/FabulaItemsProvider/Items/P278_RotatingPlayingCard.swift
@@ -32,12 +32,14 @@ fileprivate struct RotatingCard: View {
                                             displaySide: $displaySide))
                 .modifier(RotatingAnimation(angle: rotationAngle))
                 .onAppear {
-                    withAnimation(.linear(duration: 5).repeatForever(autoreverses: false)) {
-                        flippingAngle = 360
-                    }
-                    
-                    withAnimation(.linear(duration: 12).repeatForever(autoreverses: false)) {
-                        rotationAngle = 360
+                    DispatchQueue.main.async {
+                        withAnimation(.linear(duration: 5).repeatForever(autoreverses: false)) {
+                            flippingAngle = 360
+                        }
+                        
+                        withAnimation(.linear(duration: 12).repeatForever(autoreverses: false)) {
+                            rotationAngle = 360
+                        }
                     }
                 }
         }


### PR DESCRIPTION
No rush on deploying this, but this should fix the rotating card view making the top icons move. Oddly enough the withAnimations just needed to be wrapped in a DispatchQueue call. In my research, it appears that withAnimations in an onAppear call need to use DispatchQueue when wrapped in a NavigationView. (Which Fabula items are). Outside of a NavigationView, I would imagine my original code would work just fine.